### PR TITLE
[CAKE-47] [사용자] 케이크 매장 리뷰 API

### DIFF
--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/StoreDetailController.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/StoreDetailController.kt
@@ -1,8 +1,6 @@
 package com.cake.customcakebackend.adapter.`in`.web
 
-import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreDetailInfoResponse
-import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreNotificationListResponse
-import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreNotificationResponse
+import com.cake.customcakebackend.adapter.`in`.web.dto.response.*
 import com.cake.customcakebackend.application.port.`in`.StoreDetailUseCase
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -32,6 +30,7 @@ class StoreDetailController(
     /**
      * getNotificationList method
      * : 매장 공지 리스트 조회
+     *
      * @author jjaen
      * @version 1.0.0
      * 작성일 2023/04/12
@@ -45,6 +44,7 @@ class StoreDetailController(
     /**
      * getNotificationDetailInfo method
      * : 매장 공지 디테일 조회
+     *
      * @author jjaen
      * @version 1.0.0
      * 작성일 2023/04/12
@@ -55,4 +55,17 @@ class StoreDetailController(
     ): StoreNotificationResponse =
         storeDetailUseCase.storeNotificationDetailInfo(notificationId)
 
+    /**
+     * getReviewList method
+     * : 매장 리뷰 리스트 조회
+     *
+     * @author jjaen
+     * @version 1.0.0
+     * 작성일 2023/04/13
+    **/
+    @GetMapping("/{storeId}/reviews")
+    fun getReviewList(
+        @PathVariable storeId: Long
+    ): ReviewListResponse =
+        storeDetailUseCase.storeReviewList(storeId)
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/DayoffResponse.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/DayoffResponse.kt
@@ -3,7 +3,6 @@ package com.cake.customcakebackend.adapter.`in`.web.dto.response
 import com.cake.customcakebackend.common.DayOfWeekUnit
 import com.cake.customcakebackend.common.DayoffType
 import com.cake.customcakebackend.domain.Dayoff
-import java.time.LocalDate
 
 data class DayoffResponse(
     val id: Long,

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/ReviewListResponse.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/ReviewListResponse.kt
@@ -1,0 +1,8 @@
+package com.cake.customcakebackend.adapter.`in`.web.dto.response
+
+import com.cake.customcakebackend.domain.Review
+
+data class ReviewListResponse(
+    val storeId: Long,
+    val reviewResponseList: List<ReviewResponse>
+)

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/ReviewResponse.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/ReviewResponse.kt
@@ -1,0 +1,39 @@
+package com.cake.customcakebackend.adapter.`in`.web.dto.response
+
+import com.cake.customcakebackend.common.OrderType
+import com.cake.customcakebackend.domain.Review
+
+data class ReviewResponse(
+    val id: Long,
+    val userNickName: String,
+    val orderInfo: OrderInfo,
+    val content: String,
+    val score: Int,
+    val createdAt: String,
+    val modifiedAt: String,
+)
+
+data class OrderInfo(
+    val orderType: OrderType,
+    val cakeOption1: String,
+    val cakeOption2: String,
+    val cakeOption3: String
+)
+
+fun Review.toResponse(
+    orderType: OrderType,
+    cakeOption1: String,
+    cakeOption2: String,
+    cakeOption3: String = "",
+    userNickName: String
+) = ReviewResponse(
+    id = this.id,
+    userNickName = userNickName,
+    orderInfo = OrderInfo(
+        orderType, cakeOption1, cakeOption2, cakeOption3
+    ),
+    content = this.content,
+    score = this.score,
+    createdAt = this.createdAt.toString(),
+    modifiedAt = this.modifiedAt.toString()
+)

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/ReviewResponse.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/in/web/dto/response/ReviewResponse.kt
@@ -1,37 +1,27 @@
 package com.cake.customcakebackend.adapter.`in`.web.dto.response
 
+import com.cake.customcakebackend.common.OrderOptionsInfo
 import com.cake.customcakebackend.common.OrderType
 import com.cake.customcakebackend.domain.Review
 
 data class ReviewResponse(
     val id: Long,
     val userNickName: String,
-    val orderInfo: OrderInfo,
+    val orderType: OrderType,
+    val orderOptionsInfo: OrderOptionsInfo,
     val content: String,
     val score: Int,
     val createdAt: String,
     val modifiedAt: String,
 )
 
-data class OrderInfo(
-    val orderType: OrderType,
-    val cakeOption1: String,
-    val cakeOption2: String,
-    val cakeOption3: String
-)
-
 fun Review.toResponse(
-    orderType: OrderType,
-    cakeOption1: String,
-    cakeOption2: String,
-    cakeOption3: String = "",
     userNickName: String
 ) = ReviewResponse(
     id = this.id,
     userNickName = userNickName,
-    orderInfo = OrderInfo(
-        orderType, cakeOption1, cakeOption2, cakeOption3
-    ),
+    orderType = this.orderType,
+    orderOptionsInfo = this.orderOptionsInfo,
     content = this.content,
     score = this.score,
     createdAt = this.createdAt.toString(),

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/DayoffPersistenceAdapter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/DayoffPersistenceAdapter.kt
@@ -17,7 +17,8 @@ class DayoffPersistenceAdapter(
 ) : DayoffPort
 {
     override fun loadDayOff(storeId: Long): List<Dayoff> =
-        jpaQueryFactory.selectFrom(QDayoffEntity.dayoffEntity)
+        jpaQueryFactory
+            .selectFrom(QDayoffEntity.dayoffEntity)
             .where(QDayoffEntity.dayoffEntity.storeId.eq(storeId))
             .fetch()
             .map { dayoffMapper.toDomain(it) }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/ReviewPersistenceAdapter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/ReviewPersistenceAdapter.kt
@@ -1,13 +1,17 @@
 package com.cake.customcakebackend.adapter.out.persistence
 
+import com.cake.customcakebackend.adapter.`in`.web.dto.response.ReviewResponse
+import com.cake.customcakebackend.adapter.`in`.web.dto.response.toResponse
 import com.cake.customcakebackend.adapter.out.persistence.mapper.ReviewMapper
 import com.cake.customcakebackend.adapter.out.persistence.repository.ReviewJpaRepository
 import com.cake.customcakebackend.application.port.out.ReviewPort
 import com.cake.customcakebackend.domain.Review
+import com.querydsl.core.Tuple
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import java.text.DecimalFormat
-import com.cake.customcakebackend.adapter.out.persistence.entity.QReviewEntity.reviewEntity as review
+import com.cake.customcakebackend.adapter.out.persistence.entity.QReviewEntity.reviewEntity as REVIEW
+import com.cake.customcakebackend.adapter.out.persistence.entity.QUserEntity.userEntity as USER
 
 @Repository
 class ReviewPersistenceAdapter(
@@ -16,25 +20,31 @@ class ReviewPersistenceAdapter(
     private val jpaQueryFactory: JPAQueryFactory
 ): ReviewPort {
     private val reviewFormat = DecimalFormat("#.#")
-    override fun loadList(storeId: Long): List<Review> =
-        jpaQueryFactory
-            .selectFrom(review)
-            .where(review.storeId.eq(storeId))
+    override fun loadNickNameAndReviewList(storeId: Long): Map<String, Review> {
+        val results: List<Tuple> = jpaQueryFactory
+            .select(USER.nickname, REVIEW)
+            .from(REVIEW)
+            .join(USER).on(REVIEW.userId.eq(USER.id))
+            .where(REVIEW.storeId.eq(storeId))
             .fetch()
-            .map { reviewMapper.toDomain(it) }
+
+        return results.associate {
+            it.get(USER.nickname)!! to reviewMapper.toDomain(it.get(REVIEW)!!)
+        }
+    }
 
     override fun calculateReviewScore(storeId: Long): Float {
-        val result: Pair<Long?, Long?>? = jpaQueryFactory
-            .select(review.score.sum(), review.count())
-            .from(review)
-            .where(review.storeId.eq(storeId))
+        val result: Pair<Int?, Long?>? = jpaQueryFactory
+            .select(REVIEW.score.sum(), REVIEW.count())
+            .from(REVIEW)
+            .where(REVIEW.storeId.eq(storeId))
             .fetch()
-            .map { it.get(0, Long::class.java) to it.get(1, Long::class.java) }.firstOrNull()
+            .map { it.get(0, Int::class.java) to it.get(1, Long::class.java) }.firstOrNull()
 
         result
             ?. let {
                 val score = it.first ?: 0
-                val count = it.second ?: 0
+                val count = it.second ?: 0L
                 return if (count == 0L) 0F else {
                     reviewFormat.format(score / count).toFloat()
                 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/ReviewPersistenceAdapter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/ReviewPersistenceAdapter.kt
@@ -3,6 +3,7 @@ package com.cake.customcakebackend.adapter.out.persistence
 import com.cake.customcakebackend.adapter.out.persistence.mapper.ReviewMapper
 import com.cake.customcakebackend.adapter.out.persistence.repository.ReviewJpaRepository
 import com.cake.customcakebackend.application.port.out.ReviewPort
+import com.cake.customcakebackend.domain.Review
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import java.text.DecimalFormat
@@ -15,6 +16,12 @@ class ReviewPersistenceAdapter(
     private val jpaQueryFactory: JPAQueryFactory
 ): ReviewPort {
     private val reviewFormat = DecimalFormat("#.#")
+    override fun loadList(storeId: Long): List<Review> =
+        jpaQueryFactory
+            .selectFrom(review)
+            .where(review.storeId.eq(storeId))
+            .fetch()
+            .map { reviewMapper.toDomain(it) }
 
     override fun calculateReviewScore(storeId: Long): Float {
         val result: Pair<Long?, Long?>? = jpaQueryFactory

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/UserPersistenceAdapter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/UserPersistenceAdapter.kt
@@ -21,17 +21,6 @@ class UserPersistenceAdapter(
         // toDomain()
     }
 
-    override fun loadNickName(userId: Long): String {
-        val userNickName = jpaQueryFactory
-            .select(USER.nickname)
-            .from(USER)
-            .where(USER.id.eq(userId))
-            .fetchOne()
-
-        return userNickName
-            ?: throw EntityNotFoundException("User id=$userId not found.")
-    }
-
     override fun save(user: User) {
         TODO("Change domain to entity and save entity.")
 //        val userEntity = userMapper.toEntity(user)

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/UserPersistenceAdapter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/UserPersistenceAdapter.kt
@@ -1,20 +1,35 @@
 package com.cake.customcakebackend.adapter.out.persistence
 
+import com.cake.customcakebackend.adapter.out.persistence.entity.QUserEntity.userEntity as USER
 import com.cake.customcakebackend.adapter.out.persistence.mapper.UserMapper
 import com.cake.customcakebackend.adapter.out.persistence.repository.UserJpaRepository
 import com.cake.customcakebackend.application.port.out.LoadUserPort
 import com.cake.customcakebackend.application.port.out.SaveUserPort
 import com.cake.customcakebackend.domain.User
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
+import javax.persistence.EntityNotFoundException
 
 @Repository
 class UserPersistenceAdapter(
     private val userMapper: UserMapper,
-    private val userJpaRepository: UserJpaRepository
+    private val userJpaRepository: UserJpaRepository,
+    private val jpaQueryFactory: JPAQueryFactory
 ) : LoadUserPort, SaveUserPort {
     override fun load(id: Long): User {
         TODO("Change entity to domain and return domain.")
         // toDomain()
+    }
+
+    override fun loadNickName(userId: Long): String {
+        val userNickName = jpaQueryFactory
+            .select(USER.nickname)
+            .from(USER)
+            .where(USER.id.eq(userId))
+            .fetchOne()
+
+        return userNickName
+            ?: throw EntityNotFoundException("User id=$userId not found.")
     }
 
     override fun save(user: User) {

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/entity/CakeDesignOrderEntity.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/entity/CakeDesignOrderEntity.kt
@@ -15,6 +15,9 @@ class CakeDesignOrderEntity (
     @Column(name = "user_id", nullable = false)
     val userId: Long,
 
+    @Column(name = "cake_item_id", nullable = false)
+    val cakeItemId: Long,
+
     // @ManyToOne
     @Column(name = "cake_option1_id", nullable = false)
     val cakeOption1Id: Long,

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/entity/ReviewEntity.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/entity/ReviewEntity.kt
@@ -1,6 +1,8 @@
 package com.cake.customcakebackend.adapter.out.persistence.entity
 
+import com.cake.customcakebackend.common.OrderOptionsInfo
 import com.cake.customcakebackend.common.OrderType
+import com.cake.customcakebackend.common.converter.JsonColumnConverter
 import javax.persistence.*
 
 @Table(name = "review")
@@ -21,6 +23,10 @@ class ReviewEntity (
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "String", length = 10, nullable = false)
     val orderType: OrderType,
+
+    @Convert(converter = JsonColumnConverter.OrderOptionsInfoConverter::class)
+    @Column(name = "order_options_info", length = 50, nullable = false)
+    val orderOptionsInfo:  OrderOptionsInfo,
 
     @Column(name = "order_id", nullable = false)
     val orderId: Long,

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/mapper/ReviewMapper.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/adapter/out/persistence/mapper/ReviewMapper.kt
@@ -12,6 +12,7 @@ class ReviewMapper : Mapper<ReviewEntity, Review> {
             userId = domain.userId,
             storeId = domain.storeId,
             orderType = domain.orderType,
+            orderOptionsInfo = domain.orderOptionsInfo,
             orderId = domain.orderId,
             content = domain.content,
             score = domain.score
@@ -24,6 +25,7 @@ class ReviewMapper : Mapper<ReviewEntity, Review> {
             storeId = entity.storeId,
             orderType = entity.orderType,
             orderId = entity.orderId,
+            orderOptionsInfo = entity.orderOptionsInfo,
             content = entity.content,
             score = entity.score,
             createdAt = entity.createdAt,

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/port/in/StoreDetailUseCase.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/port/in/StoreDetailUseCase.kt
@@ -1,5 +1,6 @@
 package com.cake.customcakebackend.application.port.`in`
 
+import com.cake.customcakebackend.adapter.`in`.web.dto.response.ReviewListResponse
 import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreDetailInfoResponse
 import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreNotificationListResponse
 import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreNotificationResponse
@@ -9,5 +10,5 @@ interface StoreDetailUseCase {
     fun storeDetailInfo(storeId: Long): StoreDetailInfoResponse
     fun storeNotificationList(storeId: Long): StoreNotificationListResponse
     fun storeNotificationDetailInfo(notificationId: Long): StoreNotificationResponse
-
+    fun storeReviewList(storeId: Long): ReviewListResponse
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/port/out/ReviewPort.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/port/out/ReviewPort.kt
@@ -3,6 +3,6 @@ package com.cake.customcakebackend.application.port.out
 import com.cake.customcakebackend.domain.Review
 
 interface ReviewPort {
-    fun loadList(storeId: Long): List<Review>
+    fun loadNickNameAndReviewList(storeId: Long): Map<String, Review>
     fun calculateReviewScore(storeId: Long): Float
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/port/out/ReviewPort.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/port/out/ReviewPort.kt
@@ -1,5 +1,8 @@
 package com.cake.customcakebackend.application.port.out
 
+import com.cake.customcakebackend.domain.Review
+
 interface ReviewPort {
+    fun loadList(storeId: Long): List<Review>
     fun calculateReviewScore(storeId: Long): Float
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/service/StoreDetailService.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/service/StoreDetailService.kt
@@ -1,17 +1,16 @@
 package com.cake.customcakebackend.application.service
 
-import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreDetailInfoResponse
-import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreNotificationListResponse
-import com.cake.customcakebackend.adapter.`in`.web.dto.response.StoreNotificationResponse
-import com.cake.customcakebackend.adapter.`in`.web.dto.response.toResponse
+import com.cake.customcakebackend.adapter.`in`.web.dto.response.*
 import com.cake.customcakebackend.application.port.`in`.StoreDetailUseCase
 import com.cake.customcakebackend.application.port.out.*
+import com.cake.customcakebackend.domain.Review
 import org.springframework.stereotype.Service
 
 @Service
 class StoreDetailService(
     private val storePort: StorePort,
     private val storeNotificationPort: StoreNotificationPort,
+    private val storeReviewPort: ReviewPort,
     private val dayOffPort: DayoffPort,
     private val cakeItemPort: CakeItemPort,
     private val reviewPort: ReviewPort,
@@ -42,5 +41,17 @@ class StoreDetailService(
 
     override fun storeNotificationDetailInfo(notificationId: Long): StoreNotificationResponse =
         storeNotificationPort.loadNotification(notificationId).toResponse()
+
+    override fun storeReviewList(storeId: Long): ReviewListResponse {
+        TODO()
+//        val reviewResponseList = reviewPort.loadList(storeId)
+//            .map {
+//                it.toResponse(
+//
+//                )
+//            }
+        // 리뷰
+        // 주문 정보
+    }
 
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/service/StoreDetailService.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/application/service/StoreDetailService.kt
@@ -3,11 +3,11 @@ package com.cake.customcakebackend.application.service
 import com.cake.customcakebackend.adapter.`in`.web.dto.response.*
 import com.cake.customcakebackend.application.port.`in`.StoreDetailUseCase
 import com.cake.customcakebackend.application.port.out.*
-import com.cake.customcakebackend.domain.Review
 import org.springframework.stereotype.Service
 
 @Service
 class StoreDetailService(
+    private val userPort: LoadUserPort,
     private val storePort: StorePort,
     private val storeNotificationPort: StoreNotificationPort,
     private val storeReviewPort: ReviewPort,
@@ -43,15 +43,9 @@ class StoreDetailService(
         storeNotificationPort.loadNotification(notificationId).toResponse()
 
     override fun storeReviewList(storeId: Long): ReviewListResponse {
-        TODO()
-//        val reviewResponseList = reviewPort.loadList(storeId)
-//            .map {
-//                it.toResponse(
-//
-//                )
-//            }
-        // 리뷰
-        // 주문 정보
+        val nickNameAndReviewList = reviewPort.loadNickNameAndReviewList(storeId)
+
+        return ReviewListResponse(storeId, nickNameAndReviewList.map { it.value.toResponse(it.key) })
     }
 
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/common/OrderOptionsInfo.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/common/OrderOptionsInfo.kt
@@ -1,0 +1,12 @@
+package com.cake.customcakebackend.common
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class OrderOptionsInfo(
+    @JsonProperty("option1")
+    val option1: String,
+    @JsonProperty("option2")
+    val option2: String,
+    @JsonProperty("option3")
+    val option3: String = "",
+)

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/common/converter/JsonColumnConverter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/common/converter/JsonColumnConverter.kt
@@ -2,6 +2,7 @@ package com.cake.customcakebackend.common.converter
 
 import com.cake.customcakebackend.common.CakeCustomSketch
 import com.cake.customcakebackend.common.DayOfWeekUnit
+import com.cake.customcakebackend.common.OrderOptionsInfo
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -68,5 +69,25 @@ class JsonColumnConverter {
                 throw IllegalArgumentException()
             }
         }
+    }
+
+    @Converter
+    class OrderOptionsInfoConverter : AttributeConverter<OrderOptionsInfo, String> {
+        override fun convertToDatabaseColumn(attribute: OrderOptionsInfo): String {
+            try {
+                return mapper.writeValueAsString(attribute)
+            } catch (e: JsonProcessingException) {
+                throw IllegalArgumentException()
+            }
+        }
+
+        override fun convertToEntityAttribute(dbData: String): OrderOptionsInfo {
+            try {
+                return mapper.readValue(dbData, OrderOptionsInfo::class.java)
+            } catch (e: IOException) {
+                throw IllegalArgumentException()
+            }
+        }
+
     }
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/domain/Review.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/domain/Review.kt
@@ -3,8 +3,8 @@ package com.cake.customcakebackend.domain
 import com.cake.customcakebackend.common.OrderType
 import java.time.LocalDateTime
 
-class Review (
-    val id: Long,
+data class Review (
+    val id: Long = 0,
     val userId: Long,
     val storeId: Long,
     val orderType: OrderType,

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/domain/Review.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcakebackend/domain/Review.kt
@@ -1,5 +1,6 @@
 package com.cake.customcakebackend.domain
 
+import com.cake.customcakebackend.common.OrderOptionsInfo
 import com.cake.customcakebackend.common.OrderType
 import java.time.LocalDateTime
 
@@ -8,6 +9,7 @@ data class Review (
     val userId: Long,
     val storeId: Long,
     val orderType: OrderType,
+    val orderOptionsInfo: OrderOptionsInfo,
     val orderId: Long,
     val content: String,
     val score: Int,

--- a/custom-cake-backend/src/main/resources/data.sql
+++ b/custom-cake-backend/src/main/resources/data.sql
@@ -87,5 +87,10 @@ VALUES (1, 1, '레이네 케이크 공지', '[4~5월 디자인케이크 클래�
   정형화된 케이크 기법이 아닌 다양한 요소와 그림들을 케이크 위에 자유롭게 표현하는 수업입니다.
   특히 자연물의 형태를 분석하고 그에 맞는 기법을 배워보는 수업입니다.');
 
+INSERT IGNORE INTO cake_design_order (id, user_id, cake_item_id, cake_option1_id, cake_option2_id, cake_option3_id,
+                                      requirements, order_status, payment_amount, purchase_confirmation_date)
+VALUES (1, 1, 1, 3, 2, 7, '레터링 문구 Happy Birthday!로 부탁드립니다.', 'PICK_UP', 55000, '2023-04-11 15:02:00');
 
 
+INSERT IGNORE INTO review (id, user_id, store_id, order_type, order_id, content, score)
+VALUES (1, 1, 1, 'DESIGN', 1, '사장님 너무 친절하시고 좋아요!', 5)

--- a/custom-cake-backend/src/main/resources/data.sql
+++ b/custom-cake-backend/src/main/resources/data.sql
@@ -92,5 +92,6 @@ INSERT IGNORE INTO cake_design_order (id, user_id, cake_item_id, cake_option1_id
 VALUES (1, 1, 1, 3, 2, 7, '레터링 문구 Happy Birthday!로 부탁드립니다.', 'PICK_UP', 55000, '2023-04-11 15:02:00');
 
 
-INSERT IGNORE INTO review (id, user_id, store_id, order_type, order_id, content, score)
-VALUES (1, 1, 1, 'DESIGN', 1, '사장님 너무 친절하시고 좋아요!', 5)
+INSERT IGNORE INTO review (id, user_id, store_id, order_type, order_id, order_options_info, content, score)
+VALUES (1, 1, 1, 'DESIGN', 1, '{\"option1\":\"CIRCLE, 1호, 1단\",\"option2\":\"초코시트, 우유생크림, 크림치즈\",\"option3\":\"아이스팩\"}',
+        '사장님 너무 친절하시고 좋아요!', 5)

--- a/custom-cake-backend/src/main/resources/schema.sql
+++ b/custom-cake-backend/src/main/resources/schema.sql
@@ -329,6 +329,7 @@ CREATE TABLE IF NOT EXISTS `review` (
 	`store_id`	                    BIGINT UNSIGNED	        NOT NULL,
 	`order_type`                    VARCHAR(10)        	    NOT NULL,       -- DESIGN or CUSTOM
 	`order_id`	                    BIGINT UNSIGNED 	    NOT NULL,       -- not foreign_key, just id
+	`order_options_info`            JSON            	    NOT NULL,       -- order options info
 	`content`	                    VARCHAR(255)	        NOT NULL,
 	`score`	                        INT	UNSIGNED            NOT NULL,       -- 1~5
     `created_at`	                TIMESTAMP DEFAULT CURRENT_TIMESTAMP                                   NOT NULL,

--- a/custom-cake-backend/src/main/resources/schema.sql
+++ b/custom-cake-backend/src/main/resources/schema.sql
@@ -305,6 +305,7 @@ CREATE TABLE IF NOT EXISTS `cake_custom_order` (
 CREATE TABLE IF NOT EXISTS `cake_design_order` (
 	`id`	                        BIGINT UNSIGNED         NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	`user_id`	                    BIGINT UNSIGNED     	NOT NULL,
+	`cake_item_id`	                BIGINT UNSIGNED     	NOT NULL,
 	`cake_option1_id`	            BIGINT UNSIGNED	        NOT NULL,
 	`cake_option2_id`	            BIGINT UNSIGNED	        NOT NULL,
 	`cake_option3_id`	            BIGINT UNSIGNED	        NULL DEFAULT NULL,

--- a/custom-cake-backend/src/test/resources/schema.sql
+++ b/custom-cake-backend/src/test/resources/schema.sql
@@ -329,6 +329,7 @@ CREATE TABLE IF NOT EXISTS `review` (
                                         `store_id`	                    BIGINT UNSIGNED	        NOT NULL,
                                         `order_type`                    VARCHAR(10)        	    NOT NULL,       -- DESIGN or CUSTOM
                                         `order_id`	                    BIGINT UNSIGNED 	    NOT NULL,       -- not foreign_key, just id
+                                        `order_options_info`            JSON            	    NOT NULL,       -- order options info
                                         `content`	                    VARCHAR(255)	        NOT NULL,
                                         `score`	                        INT	UNSIGNED            NOT NULL,       -- 1~5
                                         `created_at`	                TIMESTAMP DEFAULT CURRENT_TIMESTAMP                                   NOT NULL,

--- a/custom-cake-backend/src/test/resources/schema.sql
+++ b/custom-cake-backend/src/test/resources/schema.sql
@@ -305,6 +305,7 @@ CREATE TABLE IF NOT EXISTS `cake_custom_order` (
 CREATE TABLE IF NOT EXISTS `cake_design_order` (
                                                    `id`	                        BIGINT UNSIGNED         NOT NULL AUTO_INCREMENT PRIMARY KEY,
                                                    `user_id`	                    BIGINT UNSIGNED     	NOT NULL,
+                                                   `cake_item_id`	                BIGINT UNSIGNED     	NOT NULL,
                                                    `cake_option1_id`	            BIGINT UNSIGNED	        NOT NULL,
                                                    `cake_option2_id`	            BIGINT UNSIGNED	        NOT NULL,
                                                    `cake_option3_id`	            BIGINT UNSIGNED	        NULL DEFAULT NULL,


### PR DESCRIPTION
[케이크 매장 리뷰 페이지 요구사항]

```
- 매장 공지 리뷰 리스트 조회 API
 
 1. 해당 매장의 모든 리뷰를 확인할 수 있다. -> paging 처리 필요!
  1-1. 전체 리뷰 개수, 리뷰 리스트(리뷰 제목, 유저 닉네임, 주문 케이크 상품 이름, (옵션), 
    별점, 리뷰 작성 날짜)를 확인할 수 있다.
 
 
 ### TODO 리뷰 사진 field 추가 ###
```
#### Response
```json
{
    "storeId": 1,
    "reviewResponseList": [
        {
            "id": 1,
            "userNickName": "kimyoungi99",
            "orderType": "DESIGN",
            "orderOptionsInfo": {
                "option1": "CIRCLE, 1호, 1단",
                "option2": "초코시트, 우유생크림, 크림치즈",
                "option3": "아이스팩"
            },
            "content": "사장님 너무 친절하시고 좋아요!",
            "score": 5,
            "createdAt": "2023-04-14T16:30:49",
            "modifiedAt": "2023-04-14T16:30:49"
        }
    ]
}
```