### PR TITLE
cicd - firebase init file 추가

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -42,6 +42,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # create firebase init setting file
+      - name: Make firebase init.hs
+        if: contains(github.ref, 'develop')
+        run: |
+          cd ./custom-cake-backend/src/main/resources/static/bootstrap/js/firebase
+          touch ./init.js
+          echo "${{ secrets.FIREBASE_INIT_FILE }}" > ./init.js
+        shell: bash
+
       # create application-dev.yml
       - name: Make application-dev.yml
         if: contains(github.ref, 'develop')


### PR DESCRIPTION

- 배포시 firebase init file 추가
```yml
 ...
      # create firebase init setting file
      - name: Make firebase init.hs
        if: contains(github.ref, 'develop')
        run: |
          cd ./custom-cake-backend/src/main/resources/static/bootstrap/js/firebase
          touch ./init.js
          echo "${{ secrets.FIREBASE_INIT_FILE }}" > ./init.js
        shell: bash
...
```