### PR TITLE
[CAKE-76] [사용자] 주문서 승인 여부 API 수정

### DIFF
--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/in/web/dto/response/ApproveCustomSheetResponse.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/in/web/dto/response/ApproveCustomSheetResponse.kt
@@ -1,5 +1,6 @@
 package com.cake.customcake.adapter.`in`.web.dto.response
 
 data class ApproveCustomSheetResponse(
-    val approve: Boolean
+    val approve: Boolean,
+    val cakeCustomSheetId: Long?
 )

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/out/persistence/CakeCustomOrderSheetPersistenceAdapter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/out/persistence/CakeCustomOrderSheetPersistenceAdapter.kt
@@ -27,15 +27,20 @@ class CakeCustomOrderSheetPersistenceAdapter(
         cakeCustomOrderSheetRepository.save(cakeCustomOrderSheetMapper.toEntity(cakeCustomOrderSheet))
     }
 
-    override fun hasSheet(storeId: Long, userId: Long): Boolean =
-        jpaQueryFactory
+    override fun hasSheet(storeId: Long, userId: Long): Pair<Boolean, Long?> {
+        val orderSheetEntity = jpaQueryFactory
             .select(CUSTOM_ORDER_SHEET)
             .from(CUSTOM_ORDER_SHEET)
-            .where(CUSTOM_ORDER_SHEET.storeId.eq(storeId),
-                CUSTOM_ORDER_SHEET.userId.eq(userId))
+            .where(
+                CUSTOM_ORDER_SHEET.storeId.eq(storeId),
+                CUSTOM_ORDER_SHEET.userId.eq(userId)
+            )
             .fetchOne()
-             ?. let { true }
-             ?: false
+
+        return orderSheetEntity
+             ?. let { (true to it.id) }
+             ?: let { (false to null) }
+    }
 
     override fun updateImage(sheet: CakeCustomOrderSheet, url: String): Long {
         val entity = cakeCustomOrderSheetMapper.toEntity(sheet)

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/port/out/CakeCustomOrderSheetPort.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/port/out/CakeCustomOrderSheetPort.kt
@@ -5,6 +5,6 @@ import com.cake.customcake.domain.CakeCustomOrderSheet
 interface CakeCustomOrderSheetPort {
     fun load(sheetId: Long) : CakeCustomOrderSheet
     fun save(cakeCustomOrderSheet: CakeCustomOrderSheet)
-    fun hasSheet(storeId: Long, userId: Long): Boolean
+    fun hasSheet(storeId: Long, userId: Long): Pair<Boolean, Long?>
     fun updateImage(sheet: CakeCustomOrderSheet, url: String): Long
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/service/CakeOrderService.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/service/CakeOrderService.kt
@@ -129,6 +129,11 @@ class CakeOrderService(
         )
     }
 
-    override fun checkApproveCustomSheet(storeId: Long, userId: Long): ApproveCustomSheetResponse =
-        ApproveCustomSheetResponse(approve = cakeCustomOrderSheetPort.hasSheet(storeId, userId))
+    override fun checkApproveCustomSheet(storeId: Long, userId: Long): ApproveCustomSheetResponse {
+        val (approve, id) = cakeCustomOrderSheetPort.hasSheet(storeId, userId)
+        return ApproveCustomSheetResponse(
+            approve = approve,
+            cakeCustomSheetId = id
+        )
+    }
 }


### PR DESCRIPTION
#### 1. 주문서 승인 여부 (수장 or 결제) API
- /api/orders/customs/status?storeId=1&userId=1
```json
{
    "approve": false,
    "cakeCustomSheetId": null
}
// or
{
    "approve": true,
    "cakeCustomSheetId": 1
}
```