### PR TITLE
[사용자] 주문서 승인 여부 API - 주문서 가격 필드 추가

### DIFF
--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/in/web/dto/response/ApproveCustomSheetResponse.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/in/web/dto/response/ApproveCustomSheetResponse.kt
@@ -2,5 +2,6 @@ package com.cake.customcake.adapter.`in`.web.dto.response
 
 data class ApproveCustomSheetResponse(
     val approve: Boolean,
-    val cakeCustomSheetId: Long?
+    val cakeCustomSheetId: Long?,
+    val price: Int
 )

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/out/persistence/CakeCustomOrderSheetPersistenceAdapter.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/adapter/out/persistence/CakeCustomOrderSheetPersistenceAdapter.kt
@@ -27,7 +27,7 @@ class CakeCustomOrderSheetPersistenceAdapter(
         cakeCustomOrderSheetRepository.save(cakeCustomOrderSheetMapper.toEntity(cakeCustomOrderSheet))
     }
 
-    override fun hasSheet(storeId: Long, userId: Long): Pair<Boolean, Long?> {
+    override fun hasSheet(storeId: Long, userId: Long): CakeCustomOrderSheet? {
         val orderSheetEntity = jpaQueryFactory
             .select(CUSTOM_ORDER_SHEET)
             .from(CUSTOM_ORDER_SHEET)
@@ -38,8 +38,7 @@ class CakeCustomOrderSheetPersistenceAdapter(
             .fetchOne()
 
         return orderSheetEntity
-             ?. let { (true to it.id) }
-             ?: let { (false to null) }
+             ?. let { cakeCustomOrderSheetMapper.toDomain(it) }
     }
 
     override fun updateImage(sheet: CakeCustomOrderSheet, url: String): Long {

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/port/out/CakeCustomOrderSheetPort.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/port/out/CakeCustomOrderSheetPort.kt
@@ -5,7 +5,7 @@ import com.cake.customcake.domain.CakeCustomOrderSheet
 interface CakeCustomOrderSheetPort {
     fun load(sheetId: Long) : CakeCustomOrderSheet
     fun save(cakeCustomOrderSheet: CakeCustomOrderSheet)
-    fun hasSheet(storeId: Long, userId: Long): Pair<Boolean, Long?>
+    fun hasSheet(storeId: Long, userId: Long): CakeCustomOrderSheet?
     fun updateImage(sheet: CakeCustomOrderSheet, url: String): Long
     fun addAdditionalImage(sheet: CakeCustomOrderSheet, url: String): Long
 }

--- a/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/service/CakeOrderService.kt
+++ b/custom-cake-backend/src/main/kotlin/com/cake/customcake/application/service/CakeOrderService.kt
@@ -136,10 +136,11 @@ class CakeOrderService(
     }
 
     override fun checkApproveCustomSheet(storeId: Long, userId: Long): ApproveCustomSheetResponse {
-        val (approve, id) = cakeCustomOrderSheetPort.hasSheet(storeId, userId)
+        val sheet = cakeCustomOrderSheetPort.hasSheet(storeId, userId)
         return ApproveCustomSheetResponse(
-            approve = approve,
-            cakeCustomSheetId = id
-        )
+                    approve = sheet?.let { true } ?: false,
+                    cakeCustomSheetId = sheet?.id,
+                    price = sheet?.paymentAmount ?: 0
+                )
     }
 }


### PR DESCRIPTION
#### 주문서 승인 여부 API - 최종 가격 추가
- /api/orders/customs/status?storeId=1&userId=2

##### 주문서 승인 O
```json
{
	"approve": true,
	"cakeCustomSheetId": 1,
	"price": 67000
}
```
##### 주문서 승인 X
```json
{
	"approve": false,
	"cakeCustomSheetId": null,
	"price": 0
}
```